### PR TITLE
(fix): bypass "route" check for signed AppAPI requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,40 @@ If you've upgraded to Nextcloud 32 and want to switch from using DSP to HaRP, fo
 5. **Install the ExApp**: Install removed ExApps, now they will be installed on `HaRP`.
 6. **Remove DSP**: Now DSP (Docker Socket Proxy) can be safely removed.
 
+## Building & Deploying HaRP from Source
+
+This section provides helper information for developing and modifying HaRP. The `nextcloud-docker-dev` environment will be used for this purpose.
+
+### Remove Any Existing HaRP Container
+
+```bash
+docker container remove --force appapi-harp || true
+````
+
+### Build a Local HaRP Image from Source
+
+```bash
+docker build -t nextcloud-appapi-harp:local .
+```
+
+### Deploy HaRP Using the Locally Built Image
+
+```bash
+docker run \
+  -e HP_SHARED_KEY="some_very_secure_password" \
+  -e NC_INSTANCE_URL="http://nextcloud.local" \
+  -e HP_LOG_LEVEL="debug" \
+  -e HP_VERBOSE_START="1" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v `pwd`/certs:/certs \
+  --name appapi-harp -h appapi-harp \
+  --restart unless-stopped \
+  --network=master_default \
+  -p 8780:8780 \
+  -p 8782:8782 \
+  -d nextcloud-appapi-harp:local
+```
+
 ## Contributing
 
 Contributions to HaRP are welcome. Feel free to open issues, discussions or submit pull requests with improvements, bug fixes, or new features.

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ This section provides helper information for developing and modifying HaRP. The 
 ### Remove Any Existing HaRP Container
 
 ```bash
-docker container remove --force appapi-harp || true
+docker container remove --force appapi-harp
 ````
 
 ### Build a Local HaRP Image from Source

--- a/development/redeploy.sh
+++ b/development/redeploy.sh
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-set -e
-
-docker container remove --force appapi-harp || true
+docker container remove --force appapi-harp
 
 docker build -t nextcloud-appapi-harp:local .
 

--- a/development/redeploy.sh
+++ b/development/redeploy.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -e
+
+docker container remove --force appapi-harp || true
+
+docker build -t nextcloud-appapi-harp:local .
+
+docker run \
+  -e HP_SHARED_KEY="some_very_secure_password" \
+  -e NC_INSTANCE_URL="http://nextcloud.local" \
+  -e HP_LOG_LEVEL="info" \
+  -e HP_VERBOSE_START="1" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v `pwd`/certs:/certs \
+  --name appapi-harp -h appapi-harp \
+  --restart unless-stopped \
+  --network=master_default \
+  -p 8780:8780 \
+  -p 8782:8782 \
+  -d nextcloud-appapi-harp:local


### PR DESCRIPTION
If the request comes from the AppAPI proxy, it does not pass the check without this change, since for requests from AppAPI we do not request ExApp data from the Nextсloud instance, and our routes are always empty.

It would be logical for already signed requests to simply not check the routes in this case.

As a result, with these changes, our logic becomes the same as without HаRP, that requests through the AppAPI function "requestToExApp" - bypass the route check.