### PR TITLE
set loginFailExit=false for frpc in ExApps

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ For remote or external Docker Engines - or if you prefer not to mount the Docker
    # frpc.toml
    serverAddr = "your.harp.server.address"   # Replace with your HP_FRP_ADDRESS host
    serverPort = 8782                         # Default port for FRP
+   loginFailExit = false                     # If the FRP (HaRP) server is unavailable, continue trying to log in.
 
    transport.tls.certFile = "certs/frp/client.crt"
    transport.tls.keyFile = "certs/frp/client.key"

--- a/exapps_dev/start.sh
+++ b/exapps_dev/start.sh
@@ -12,6 +12,7 @@ if [ -n "$HP_SHARED_KEY" ]; then
         cat <<EOF > /frpc.toml
 serverAddr = "$HP_FRP_ADDRESS"
 serverPort = $HP_FRP_PORT
+loginFailExit = false
 
 transport.tls.enable = true
 transport.tls.certFile = "/certs/frp/client.crt"
@@ -34,6 +35,7 @@ EOF
         cat <<EOF > /frpc.toml
 serverAddr = "$HP_FRP_ADDRESS"
 serverPort = $HP_FRP_PORT
+loginFailExit = false
 
 transport.tls.enable = false
 


### PR DESCRIPTION
This is a very important thing that we missed.

In my local setup, the HaRP container starts **after** ExApps, and `frpc` without this change does not make further connection attempts if the first connection was unsuccessful.

As a result, I need to restart them manually, which is obviously OK for a developer, but not in production.

I don't see any downsides to this.