### PR TITLE
feat: endpoint to get HaRP version

### DIFF
--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -465,6 +465,15 @@ def resolve_ip(hostname: str) -> str:
 
 
 ###############################################################################
+# Misc routes
+###############################################################################
+
+
+async def get_info(request: web.Request):
+    return web.json_response({"version": 0.2})
+
+
+###############################################################################
 # ExApp routes
 ###############################################################################
 
@@ -1607,6 +1616,8 @@ def _get_certificate_update_command(os_info_content: str | None) -> list[str] | 
 
 def create_web_app() -> web.Application:
     app = web.Application()
+
+    app.router.add_get("/info", get_info)
 
     # ExApp routes
     app.router.add_post("/exapp_storage/{app_id}", add_exapp)


### PR DESCRIPTION
We will need this in AppAPI in the near future, some kind of endpoint so that we can tell the admins from AppAPI that their HaRP is old and not compatible with the new version of AppAPI. (_as currently with DSP it is a disaster_)