### PR TITLE
Fix nginx example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ server {
     server_name nextcloud.com;
 
     location /exapps/ {
-        proxy_pass http://127.0.0.1:8780/;
+        proxy_pass http://127.0.0.1:8780;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
removed / in nginx example config so routing is working again

Fixing: [#42](https://github.com/nextcloud/HaRP/issues/42)

All credits to @pmarini-nc who found the problem and the fix