### PR TITLE
fix: removed non-needed second call to start SPOE agent

### DIFF
--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -1670,4 +1670,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-    SPOA_AGENT.run()


### PR DESCRIPTION
This is not a critical bug, but it can lead to log pollution when the container is shut down, which is not good.