### PR TITLE
fix: do not expose the unnecessary ports

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -244,6 +244,7 @@ if [ ! -f "/frps.toml" ]; then
 cat <<EOF >/frps.toml
 bindAddr = "${FRP_HOST}"
 bindPort = ${FRP_PORT}
+proxyBindAddr = "127.0.0.1"
 
 transport.tls.force = true
 transport.tls.certFile = "/certs/frp/server.crt"
@@ -269,6 +270,7 @@ EOF
 cat <<EOF >/frps.toml
 bindAddr = "${FRP_HOST}"
 bindPort = ${FRP_PORT}
+proxyBindAddr = "127.0.0.1"
 
 transport.tls.force = false
 


### PR DESCRIPTION
Closes #66

All these ports are used through HaProxy/Frp, which is running on 8782.
There's no need to bind them to interface 0.0.0.0 (_unless we missed something_).