### PR TITLE
chore: forbid non-ASCII characters in the HP_SHARED_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ HaRP is configured via several environment variables. Here are the key variables
 - **`HP_SHARED_KEY`** (or **`HP_SHARED_KEY_FILE`**)
   - **Description:** A secret token used for authentication between services.
   - **Requirement:** Must be set at runtime. Use only one of these methods.
+  - **Important:** Must contain only ASCII characters (a-z, A-Z, 0-9, and common symbols).
 
 - **`NC_INSTANCE_URL`**
   - **Description:** The base URL of your Nextcloud instance.

--- a/start.sh
+++ b/start.sh
@@ -92,6 +92,15 @@ if [ -z "$HP_SHARED_KEY" ]; then
     echo "ERROR: Either HP_SHARED_KEY or HP_SHARED_KEY_FILE must be set."
     exit 1
 fi
+
+# Validate HP_SHARED_KEY contains only ASCII characters (required by SPOE library)
+NON_ASCII_COUNT=$(printf '%s' "$HP_SHARED_KEY" | LC_ALL=C tr -d '\040-\176' | wc -c)
+if [ "$NON_ASCII_COUNT" -gt 0 ]; then
+    echo "ERROR: HP_SHARED_KEY contains non-ASCII characters."
+    echo "Please use only printable ASCII characters (a-z, A-Z, 0-9, and symbols like !@#\$%^&*...)."
+    exit 1
+fi
+
 export HP_SHARED_KEY
 
 # Check if the required environment variables are set


### PR DESCRIPTION
Fixes #52

The check uses `tr -d '\040-\176'` to remove all printable ASCII characters (octal 040-176 = decimal 32-126 = space to tilde). If anything remains, the key contains non-ASCII or control characters.