### PR TITLE
fix: increase SPOE processing timeout from 5s to 30s

### DIFF
--- a/spoe-agent.conf
+++ b/spoe-agent.conf
@@ -8,7 +8,7 @@ spoe-agent exapps-agent
     option var-prefix exapps
     timeout hello 10s
     timeout idle 1m
-    timeout processing 5s
+    timeout processing 30s
     use-backend agents
 
 spoe-message exapps_msg
@@ -21,7 +21,7 @@ spoe-agent exapps-agent
     option var-prefix exapps
     timeout hello 10s
     timeout idle 1m
-    timeout processing 5s
+    timeout processing 30s
     use-backend agents
 
 spoe-message exapps_response_status_msg


### PR DESCRIPTION
Fixes **Flaky** test in AppAPI: https://github.com/nextcloud/app_api/pull/783

The SPOE agent and K8s HTTP server share a Python `asyncio` event loop. During heavy K8s operations (deploy, stop, expose), the event loop can be blocked long enough that HAProxy's `5s` SPOE processing timeout expires before the routing decision is returned.

This causes HAProxy to return `503` with `<NOSRV>` because no backend is selected.

Increase timeout processing to `30s` in both SPOE engine configs. The SPOE handler itself completes in microseconds - the `30s` headroom covers event loop contention during concurrent K8s API calls.
