### PR TITLE
fix(k8s): share one PVC across multi-role ExApp Deployments

### DIFF
--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -155,7 +155,9 @@ class ExAppName(BaseModel):
     @computed_field
     @property
     def exapp_container_volume(self) -> str:
-        return f"{self.exapp_container_name}_data"
+        # Role-agnostic multirole K8s Deployments share one PVC and mount it at the same path as APP_PERSISTENT_STORAGE
+        base = f"nc_app_{self.instance_id}_{self.name}" if self.instance_id else f"nc_app_{self.name}"
+        return f"{base}_data"
 
     @computed_field
     @property
@@ -2548,6 +2550,9 @@ async def k8s_exapp_create(request: web.Request):
     payload = await _parse_json_payload(request, CreateExAppPayload)
     deployment_name = payload.exapp_k8s_name
     pvc_name = payload.exapp_k8s_volume_name
+    base_exapp_name = _sanitize_k8s_name(
+        f"nc_app_{payload.instance_id}_{payload.name}" if payload.instance_id else f"nc_app_{payload.name}"
+    )
 
     LOGGER.info("Creating K8s resources for '%s' (ns=%s).", payload.name, K8S_NAMESPACE)
 
@@ -2557,9 +2562,9 @@ async def k8s_exapp_create(request: web.Request):
         "metadata": {
             "name": pvc_name,
             "labels": {
-                "app": deployment_name,
-                "app.kubernetes.io/name": deployment_name,
-                "app.kubernetes.io/component": "exapp",
+                "app.kubernetes.io/name": base_exapp_name,
+                "app.kubernetes.io/part-of": base_exapp_name,
+                "app.kubernetes.io/component": "exapp-data",
             },
         },
         "spec": {


### PR DESCRIPTION
When a K8s ExApp declares multiple `<k8s-service-roles>`, HaRP was creating a separate PVC per role (`nc-app-{name}-{role}-data`) and mounting each at a role-suffixed path. But AppAPI sets `APP_PERSISTENT_STORAGE=/nc_app_{appId}_data` - no role suffix,  so the ExApp would write to a path that didn't match the PVC mountpoint.

This makes the PVC role-agnostic by dropping `role_suffix` from `exapp_container_volume`. All roles of one ExApp now share a single PVC mounted at the same path as `APP_PERSISTENT_STORAGE`. Deployment names stay per-role so each role still gets its own Deployment/pod/selector. PVC labels also switched to role-agnostic ones (`part-of`, `name`, `component=exapp-data`) since the PVC is no longer tied to a specific role.

Note: if anyone had a multi-role ExApp deployed with the pre-patch build, the old per-role PVCs will orphan after this goes in. They're empty (that's literally the bug), so there's no data to lose — just `kubectl delete pvc` the old names if you care about cleanup.