### PR TITLE
fix: reject HP_SHARED_KEY with FRP-incompatible characters

### DIFF
--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -728,7 +728,7 @@ async def get_info(request: web.Request):
             k8s_status["reachable"] = False
 
     return web.json_response({
-        "version": 0.3,
+        "version": 0.4,
         "docker": True,
         "kubernetes": k8s_status,
     })

--- a/start.sh
+++ b/start.sh
@@ -123,6 +123,19 @@ if [ "$NON_ASCII_COUNT" -gt 0 ]; then
     exit 1
 fi
 
+# Reject characters that break the generated FRP TOML config or get mangled by
+# strip_quotes:
+#   "  - terminates the TOML basic string used for metadatas.token
+#   \  - starts a TOML escape sequence inside that string
+#   '  - silently stripped from the end of the value by strip_quotes() below
+FORBIDDEN_COUNT=$(printf '%s' "$HP_SHARED_KEY" | LC_ALL=C tr -cd "\"\\\\'" | wc -c)
+if [ "$FORBIDDEN_COUNT" -gt 0 ]; then
+    echo "ERROR: HP_SHARED_KEY contains a forbidden character."
+    echo "The following characters are not allowed: double quote (\"), single quote ('), backslash (\\)."
+    echo "Please choose a password without these characters."
+    exit 1
+fi
+
 # Strip surrounding quotes if user accidentally included them in env vars
 HP_SHARED_KEY="$(strip_quotes "$HP_SHARED_KEY")"
 export HP_SHARED_KEY

--- a/start.sh
+++ b/start.sh
@@ -123,22 +123,22 @@ if [ "$NON_ASCII_COUNT" -gt 0 ]; then
     exit 1
 fi
 
-# Reject characters that break the generated FRP TOML config or get mangled by
-# strip_quotes:
-#   "  - terminates the TOML basic string used for metadatas.token
-#   \  - starts a TOML escape sequence inside that string
-#   '  - silently stripped from the end of the value by strip_quotes() below
-FORBIDDEN_COUNT=$(printf '%s' "$HP_SHARED_KEY" | LC_ALL=C tr -cd "\"\\\\'" | wc -c)
-if [ "$FORBIDDEN_COUNT" -gt 0 ]; then
-    echo "ERROR: HP_SHARED_KEY contains a forbidden character."
-    echo "The following characters are not allowed: double quote (\"), single quote ('), backslash (\\)."
-    echo "Please choose a password without these characters."
-    exit 1
-fi
-
 # Strip surrounding quotes if user accidentally included them in env vars
 HP_SHARED_KEY="$(strip_quotes "$HP_SHARED_KEY")"
 export HP_SHARED_KEY
+
+# After stripping any surrounding quotes, the remaining value must not contain
+# characters that would corrupt the generated FRP TOML config line
+# `metadatas.token = "..."`:
+#   "  - terminates the TOML basic string
+#   \  - starts a TOML escape sequence inside that string
+FORBIDDEN_COUNT=$(printf '%s' "$HP_SHARED_KEY" | LC_ALL=C tr -cd '"\\' | wc -c)
+if [ "$FORBIDDEN_COUNT" -gt 0 ]; then
+    echo "ERROR: HP_SHARED_KEY contains a forbidden character."
+    echo "The following characters are not allowed: double quote (\"), backslash (\\)."
+    echo "Please choose a password without these characters."
+    exit 1
+fi
 
 # Strip surrounding quotes from other commonly affected environment variables
 NC_INSTANCE_URL="$(strip_quotes "$NC_INSTANCE_URL")"


### PR DESCRIPTION
Reject `HP_SHARED_KEY` values that contain `"` or `\` after the existing `strip_quotes` normalization, with a clear error message naming the forbidden characters. These characters otherwise corrupt the generated FRP TOML line `metadatas.token = "..."` and cause `frpc` to fail at startup.

The check runs **after** `strip_quotes` so that accidentally-wrapped values like `"secret"` / `'secret'` (the use case PR #83 added `strip_quotes` for) keep working. The single-quote character is intentionally not forbidden: it is valid inside a TOML basic string and rejecting it would break legitimate apostrophe-in-passphrase values (e.g. `don'tguessit`).

Also bumps `/info` endpoint version to 0.4.

Fixes #103