### PR TITLE
fix: tolerate agent stalls and self-heal instead of dropping all ExApp routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,10 @@ COPY --chmod=664 spoe-agent.conf /etc/haproxy/spoe-agent.conf
 COPY --chmod=755 haproxy_agent.py /usr/local/bin/haproxy_agent.py
 
 ENTRYPOINT ["start.sh"]
+# The haproxy base image sets STOPSIGNAL SIGUSR1 (graceful stop for haproxy as PID 1).
+# PID 1 is now the supervising start.sh, and the kernel drops default-disposition
+# signals for PID 1, so USR1 would be ignored and `docker stop` would end in SIGKILL.
+STOPSIGNAL SIGTERM
 HEALTHCHECK --interval=10s --timeout=10s --retries=9 CMD /healthcheck.sh
 
 LABEL com.centurylinklabs.watchtower.enable="false"

--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ HaRP is configured via several environment variables. Here are the key variables
   - **Default:** `warning`
   - **Possible Values:** `debug`, `info`, `warning`, `error`
 
+- **`HP_WATCHDOG_ENABLED`** / **`HP_WATCHDOG_INTERVAL`** / **`HP_WATCHDOG_FAILS`**
+  - **Description:** Self-healing watchdog. Every `HP_WATCHDOG_INTERVAL` seconds the container probes the internal agent (`GET /heartbeat`); after `HP_WATCHDOG_FAILS` consecutive failures the agent is killed and the container exits so that the Docker restart policy (`--restart unless-stopped` in the examples above) brings it back in a clean state. The death of any core process (agent, frps, frpc, HAProxy) also stops the container now instead of leaving it running half-broken.
+  - **Default:** `HP_WATCHDOG_ENABLED="true"`, `HP_WATCHDOG_INTERVAL="10"`, `HP_WATCHDOG_FAILS="12"`. Each failed probe can additionally spend the probe's own 5s timeout, so with the defaults a dead agent is detected in about 2 minutes and a hung-but-connectable one in about 3 minutes.
+  - **Reloading HAProxy:** sending `SIGHUP` reloads the HAProxy configuration and certificates without restarting the container (same as before): `docker exec appapi-harp kill -HUP 1`. Prefer this over `docker kill -s HUP`: after any `docker kill` the Docker daemon treats the container as manually stopped and will not auto-restart it on its next exit until it is started manually again.
+
 - **`HP_VERBOSE_START`**
   - **Description:** Flag that determines whether to output verbose logging to the console during  container startup.
   - **Default:** `1`

--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -42,6 +42,7 @@ frontend ex_apps
     http-request return status 401 content-type text/plain string "401 Unauthorized" if { var(txn.exapps.unauthorized) -m int eq 1 }
     http-request return status 403 content-type text/plain string "403 Forbidden" if { var(txn.exapps.forbidden) -m int eq 1 }
     http-request return status 404 content-type text/plain string "404 Not Found" if { var(txn.exapps.not_found) -m int eq 1 }
+    http-request return status 503 content-type text/plain string "503 Service Unavailable (HaRP)" if !{ var(txn.exapps.backend) -m found }
     use_backend %[var(txn.exapps.backend)]
 
 ###############################################################################
@@ -56,6 +57,7 @@ _HTTPS_FRONTEND_     http-request silent-drop if { var(txn.exapps.bad_request) -
 _HTTPS_FRONTEND_     http-request return status 401 content-type text/plain string "401 Unauthorized" if { var(txn.exapps.unauthorized) -m int eq 1 }
 _HTTPS_FRONTEND_     http-request return status 403 content-type text/plain string "403 Forbidden" if { var(txn.exapps.forbidden) -m int eq 1 }
 _HTTPS_FRONTEND_     http-request return status 404 content-type text/plain string "404 Not Found" if { var(txn.exapps.not_found) -m int eq 1 }
+_HTTPS_FRONTEND_     http-request return status 503 content-type text/plain string "503 Service Unavailable (HaRP)" if !{ var(txn.exapps.backend) -m found }
 _HTTPS_FRONTEND_     use_backend %[var(txn.exapps.backend)]
 
 ###############################################################################
@@ -119,5 +121,8 @@ backend agents
     mode tcp
     timeout connect 5s
     timeout server  3m
+    # Tolerate short agent stalls: a check fails only after 10s without a SPOP HELLO
+    # reply, DOWN only after 5 consecutive failures.
+    timeout check 10s
     option spop-check
-    server agent1 ${HP_SPOA_ADDRESS} check
+    server agent1 ${HP_SPOA_ADDRESS} check inter 2s fall 5 rise 2

--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import collections
-import contextlib
 import io
 import ipaddress
 import json
@@ -68,6 +67,10 @@ NC_REQ_URL = NC_INSTANCE_URL.removesuffix("/").removesuffix("/index.php")
 EX_APP_URL = f"{NC_REQ_URL}/index.php/apps/app_api/harp/exapp-meta"
 USER_INFO_URL = f"{NC_REQ_URL}/index.php/apps/app_api/harp/user-info"
 EXCLUDE_HEADERS_USER_INFO = {"host", "content-length"}
+
+# Keep total below the SPOE `timeout processing` (30s); aiohttp's default is 5 minutes.
+NC_HTTP_TIMEOUT = aiohttp.ClientTimeout(total=25.0, connect=5.0)
+_nc_session: aiohttp.ClientSession | None = None
 
 SPOA_AGENT = SpoaServer()
 DOCKER_API_HOST = "127.0.0.1"
@@ -387,6 +390,17 @@ async def get_session(pass_cookie: str) -> NcUser | None:
 async def exapps_msg(
     path: str, headers: str, client_ip: ipaddress.IPv4Address | ipaddress.IPv6Address, pass_cookie: str
 ) -> AckPayload:
+    """An exception would kill the SPOA connection; a zero-action ACK hangs the stream until `timeout processing`."""
+    try:
+        return await _exapps_msg(path, headers, client_ip, pass_cookie)
+    except Exception:
+        LOGGER.exception("Unhandled error while processing request to path=%s", path)
+        return AckPayload().set_txn_var("agent_error", 1)
+
+
+async def _exapps_msg(
+    path: str, headers: str, client_ip: ipaddress.IPv4Address | ipaddress.IPv6Address, pass_cookie: str
+) -> AckPayload:
     reply = AckPayload()
     request_headers = parse_headers(headers)
     client_ip_str = str(get_true_client_ip(client_ip, request_headers))
@@ -527,7 +541,7 @@ async def exapps_msg(
             ip_address(exapp_record.host)
             exapp_record.resolved_host = exapp_record.host
         except ValueError:
-            exapp_record.resolved_host = resolve_ip(exapp_record.host)
+            exapp_record.resolved_host = await resolve_ip(exapp_record.host)
         if not exapp_record.resolved_host:
             LOGGER.error("Cannot resolve '%s' to IP address.", exapp_record.host)
             return reply.set_txn_var("not_found", 1)
@@ -542,6 +556,15 @@ async def exapps_msg(
 
 @SPOA_AGENT.handler("exapps_response_status_msg")
 async def exapps_response_status_msg(status: int, client_ip: str, statuses_to_trigger_bp: str) -> AckPayload:
+    """Top-level SPOA entrypoint, see exapps_msg for why it must never raise."""
+    try:
+        return await _exapps_response_status_msg(status, client_ip, statuses_to_trigger_bp)
+    except Exception:
+        LOGGER.exception("Unhandled error while processing a response status message")
+        return AckPayload().set_txn_var("bp_error", 1)
+
+
+async def _exapps_response_status_msg(status: int, client_ip: str, statuses_to_trigger_bp: str) -> AckPayload:
     reply = AckPayload()
     if not statuses_to_trigger_bp:
         return reply.set_txn_var("bp_triggered", 0)
@@ -595,8 +618,31 @@ def parse_headers(headers_str: str) -> dict[str, str]:
     return headers
 
 
+def _get_nc_session() -> aiohttp.ClientSession:
+    """Shared pooled session for Nextcloud requests: bounded connector, NC_HTTP_TIMEOUT applied."""
+    global _nc_session
+    if _nc_session is None or _nc_session.closed:
+        # DummyCookieJar: client cookies are forwarded explicitly per request; the shared
+        # session must never store Set-Cookie responses, or one user's Nextcloud session
+        # cookies would be replayed on other users' requests.
+        _nc_session = aiohttp.ClientSession(
+            timeout=NC_HTTP_TIMEOUT,
+            # limit=100 is the aiohttp default; a tighter cap delays cold-cache re-auth bursts by whole waves.
+            connector=aiohttp.TCPConnector(limit=100),
+            cookie_jar=aiohttp.DummyCookieJar(),
+        )
+    return _nc_session
+
+
+async def _close_nc_session(_app: web.Application = None) -> None:
+    global _nc_session
+    if _nc_session is not None and not _nc_session.closed:
+        await _nc_session.close()
+        _nc_session = None
+
+
 async def nc_get_exapp(app_id: str) -> ExApp | None:
-    async with aiohttp.ClientSession() as session, session.get(
+    async with _get_nc_session().get(
         EX_APP_URL, headers={"harp-shared-key": SHARED_KEY}, params={"appId": app_id}
     ) as resp:
         if not resp.ok:
@@ -691,7 +737,7 @@ async def _get_or_fetch_exapp(exapp_id: str) -> ExApp | None:
 async def nc_get_user(app_id: str, all_headers: dict[str, str]) -> NcUser | None:
     ext_headers = {k: v for k, v in all_headers.items() if k.lower() not in EXCLUDE_HEADERS_USER_INFO}
     LOGGER.debug("all_headers = %s\next_headers = %s", str(all_headers), str(ext_headers))
-    async with aiohttp.ClientSession() as session, session.get(
+    async with _get_nc_session().get(
         USER_INFO_URL,
         headers={**ext_headers, "harp-shared-key": SHARED_KEY},
         params={"appId": app_id},
@@ -706,22 +752,32 @@ async def nc_get_user(app_id: str, all_headers: dict[str, str]) -> NcUser | None
         return NcUser.model_validate(data)
 
 
-def resolve_ip(hostname: str) -> str:
-    with contextlib.suppress(socket.gaierror):
-        addr_info = socket.getaddrinfo(hostname, None)
-        for family, _, _, _, sockaddr in addr_info:
-            if family == socket.AF_INET:  # IPv4
-                return sockaddr[0]
-        # If no IPv4, return first IPv6
-        for family, _, _, _, sockaddr in addr_info:
-            if family == socket.AF_INET6:  # IPv6
-                return sockaddr[0]
+async def resolve_ip(hostname: str) -> str:
+    # Blocking getaddrinfo here would freeze the whole event loop; resolve in the executor, time-capped.
+    loop = asyncio.get_running_loop()
+    try:
+        # 10s cap: enough for one full resolver retry cycle, far below the 30s SPOE budget.
+        addr_info = await asyncio.wait_for(loop.getaddrinfo(hostname, None), timeout=10.0)
+    except (socket.gaierror, TimeoutError):
+        return ""
+    for family, _, _, _, sockaddr in addr_info:
+        if family == socket.AF_INET:  # IPv4
+            return sockaddr[0]
+    # If no IPv4, return first IPv6
+    for family, _, _, _, sockaddr in addr_info:
+        if family == socket.AF_INET6:  # IPv6
+            return sockaddr[0]
     return ""
 
 
 ###############################################################################
 # Misc routes
 ###############################################################################
+
+
+async def get_heartbeat(request: web.Request):
+    """Liveness probe for healthcheck.sh and the start.sh watchdog; unlike /info it does no network I/O."""
+    return web.json_response({"status": "ok"})
 
 
 async def get_info(request: web.Request):
@@ -3127,6 +3183,7 @@ async def k8s_exapp_expose(request: web.Request):
 def create_web_app() -> web.Application:
     app = web.Application()
 
+    app.router.add_get("/heartbeat", get_heartbeat)
     app.router.add_get("/info", get_info)
 
     # ExApp routes
@@ -3156,6 +3213,7 @@ def create_web_app() -> web.Application:
     app.router.add_post("/k8s/exapp/install_certificates", k8s_exapp_install_certificates)
     app.router.add_post("/k8s/exapp/expose", k8s_exapp_expose)
     app.on_shutdown.append(_close_k8s_session)
+    app.on_shutdown.append(_close_nc_session)
     return app
 
 
@@ -3175,12 +3233,27 @@ async def run_http_server(host="127.0.0.1", port=8200):
 ###############################################################################
 
 
+async def _loop_lag_monitor():
+    """Log when the event loop was blocked: everything in this process shares it, so a stall is a full outage."""
+    interval = 1.0
+    loop = asyncio.get_running_loop()
+    expected = loop.time() + interval
+    while True:
+        await asyncio.sleep(max(0.0, expected - loop.time()))
+        now = loop.time()
+        lag = now - expected
+        if lag > 1.0:
+            LOGGER.warning("Event loop was unresponsive for %.1f seconds", lag)
+        expected = now + interval
+
+
 async def main():
     spoa_task = asyncio.create_task(SPOA_AGENT._run(host=SPOA_HOST, port=SPOA_PORT))  # noqa
     http_task = asyncio.create_task(run_http_server(host="127.0.0.1", port=8200))
+    lag_task = asyncio.create_task(_loop_lag_monitor())
 
     LOGGER.info("Starting both servers: SPOA on %s:%d, HTTP on 127.0.0.1:8200", SPOA_HOST, SPOA_PORT)
-    await asyncio.gather(spoa_task, http_task)
+    await asyncio.gather(spoa_task, http_task, lag_task)
 
 
 if __name__ == "__main__":

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -27,9 +27,10 @@ if ! command -v nc >/dev/null 2>&1; then
   exit 1
 fi
 
-# 2) Check SPOE Agent Control API (Python HTTP) on 127.0.0.1:8200
-if ! nc -z 127.0.0.1 8200; then
-  echo "ERROR: Data Plane API not responding on 127.0.0.1:8200"
+# 2) Check the agent answers HTTP on 127.0.0.1:8200: a wedged agent still accepts TCP,
+#    so `nc -z` cannot detect it. The SPOA listener shares the same event loop.
+if ! curl -fsS --noproxy '*' --max-time 5 http://127.0.0.1:8200/heartbeat >/dev/null 2>&1; then
+  echo "ERROR: HaRP agent is not responding on 127.0.0.1:8200"
   exit 1
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# bash (not sh): process supervision at the bottom relies on `wait -n`.
 
 set -e
 
@@ -29,6 +30,16 @@ HP_WAIT_AGENT_HTTP=${HP_WAIT_AGENT_HTTP:-60}
 HP_WAIT_SPOA=${HP_WAIT_SPOA:-60}
 HP_WAIT_FRP=${HP_WAIT_FRP:-30}
 HP_WAIT_INTERVAL=${HP_WAIT_INTERVAL:-0.5}
+
+# Watchdog: after roughly HP_WATCHDOG_FAILS x (HP_WATCHDOG_INTERVAL + curl's 5s timeout)
+# seconds without /heartbeat the agent is killed and the container exits so the Docker
+# restart policy revives it.
+HP_WATCHDOG_ENABLED=${HP_WATCHDOG_ENABLED:-true}
+HP_WATCHDOG_INTERVAL=${HP_WATCHDOG_INTERVAL:-10}
+HP_WATCHDOG_FAILS=${HP_WATCHDOG_FAILS:-12}
+# Non-numeric or zero values would turn the watchdog into a busy loop (a failing `sleep` retries instantly).
+[ "$HP_WATCHDOG_INTERVAL" -ge 1 ] 2>/dev/null || { echo "WARNING: invalid HP_WATCHDOG_INTERVAL '${HP_WATCHDOG_INTERVAL}', using 10."; HP_WATCHDOG_INTERVAL=10; }
+[ "$HP_WATCHDOG_FAILS" -ge 1 ] 2>/dev/null || { echo "WARNING: invalid HP_WATCHDOG_FAILS '${HP_WATCHDOG_FAILS}', using 12."; HP_WATCHDOG_FAILS=12; }
 
 HP_VERBOSE_START=${HP_VERBOSE_START:-1}
 log() {
@@ -81,7 +92,8 @@ wait_for_http() {
     url="$1"; timeout="${2:-60}"; interval="${3:-0.5}"
     start_ts="$(date +%s)"
     while :; do
-        if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
+        # --noproxy: internal loopback probes must ignore any http_proxy environment.
+        if curl -fsS --noproxy '*' --max-time 2 "$url" >/dev/null 2>&1; then
             return 0
         fi
         now="$(date +%s)"; elapsed=$(( now - start_ts ))
@@ -92,6 +104,30 @@ wait_for_http() {
         sleep "$interval"
     done
 }
+
+# shellcheck disable=SC2329  # invoked via trap
+_shutdown() {
+    trap - TERM INT USR1
+    set +e  # may fire while `set -e` is still active during startup
+    log "INFO: Stop signal received, shutting down HaRP processes..."
+    [ -n "${WATCHDOG_PID:-}" ] && kill "$WATCHDOG_PID" 2>/dev/null
+    # Unquoted expansions: still-unset PIDs simply disappear from the argument list.
+    # shellcheck disable=SC2086
+    kill -TERM ${HAPROXY_PID:-} ${AGENT_PID:-} ${FRPS_PID:-} ${FRPC_PID:-} 2>/dev/null
+    wait
+    exit 0
+}
+# Install the stop handler before doing anything slow (certificate generation, service
+# startup waits), so a `docker stop` during startup exits cleanly instead of hitting
+# Docker's 10s SIGKILL: the kernel drops default-disposition signals for PID 1.
+# USR1 too: it was the image's stop signal while haproxy was PID 1, so honor it as well.
+trap _shutdown TERM INT USR1
+
+# Forward SIGHUP to the HAProxy master for a live config/certificate reload, matching
+# the behavior when HAProxy was PID 1. The `|| true` matters: before HAProxy is started
+# the kill fails, and a failing trap command under the startup `set -e` would abort PID 1.
+# shellcheck disable=SC2086
+trap 'kill -HUP ${HAPROXY_PID:-} 2>/dev/null || true' HUP
 
 # ----------------------------------------------------------------------------
 # Resolve HP_SHARED_KEY once for the whole process (env or file)
@@ -427,17 +463,20 @@ EOF
 fi
 
 log "INFO: Starting Python HaProxy Agent on 127.0.0.1:8200 and ${HP_SPOA_ADDRESS}..."
-nohup python3 /usr/local/bin/haproxy_agent.py &
+python3 /usr/local/bin/haproxy_agent.py &
+AGENT_PID=$!
 
-# Wait deterministically for the agent to be ready (HTTP) and for SPOA (TCP)
-log "INFO: Waiting for HaRP Agent HTTP (GET http://127.0.0.1:8200/info) to be ready..."
-wait_for_http "http://127.0.0.1:8200/info" "$HP_WAIT_AGENT_HTTP" "$HP_WAIT_INTERVAL"
+# Wait deterministically for the agent to be ready (HTTP) and for SPOA (TCP).
+# Probe /heartbeat, not /info: /info can block on a K8s API reachability check.
+log "INFO: Waiting for HaRP Agent HTTP (GET http://127.0.0.1:8200/heartbeat) to be ready..."
+wait_for_http "http://127.0.0.1:8200/heartbeat" "$HP_WAIT_AGENT_HTTP" "$HP_WAIT_INTERVAL"
 
 log "INFO: Waiting for SPOA port ${HP_SPOA_ADDRESS}..."
 wait_for_tcp "$SPOA_HOST" "$SPOA_PORT" "$HP_WAIT_SPOA" "$HP_WAIT_INTERVAL"
 
 log "INFO: Starting FRP server on ${HP_FRP_ADDRESS}..."
 frps -c "${CFG_DIR}/frps.toml" &
+FRPS_PID=$!
 
 # Wait for FRP port to be listening before starting frpc
 LOCAL_FRP_HOST="$FRP_HOST"
@@ -445,10 +484,59 @@ LOCAL_FRP_HOST="$FRP_HOST"
 log "INFO: Waiting for FRP server port ${LOCAL_FRP_HOST}:${FRP_PORT}..."
 wait_for_tcp "$LOCAL_FRP_HOST" "$FRP_PORT" "$HP_WAIT_FRP" "$HP_WAIT_INTERVAL"
 
+FRPC_PID=""
 if [ -e "/var/run/docker.sock" ]; then
   log "INFO: Starting FRP client for Docker Engine..."
   frpc -c "${CFG_DIR}/frpc-docker.toml" &
+  FRPC_PID=$!
 fi
 
 log "INFO: Starting HAProxy..."
-exec haproxy -f "${CFG_DIR}/haproxy.cfg" -W -db
+haproxy -f "${CFG_DIR}/haproxy.cfg" -W -db &
+HAPROXY_PID=$!
+
+# ----------------------------------------------------------------------------
+# Supervision: the death of any critical process stops the container so the
+# Docker restart policy (--restart unless-stopped) can revive it.
+# ----------------------------------------------------------------------------
+set +e
+
+WATCHDOG_PID=""
+if [ "$HP_WATCHDOG_ENABLED" = "true" ]; then
+    (
+        fails=0
+        while :; do
+            sleep "$HP_WATCHDOG_INTERVAL"
+            if curl -fsS --noproxy '*' --max-time 5 http://127.0.0.1:8200/heartbeat >/dev/null 2>&1; then
+                fails=0
+            else
+                fails=$((fails + 1))
+                echo "WARNING: HaRP agent heartbeat failed (${fails}/${HP_WATCHDOG_FAILS})."
+                if [ "$fails" -ge "$HP_WATCHDOG_FAILS" ]; then
+                    echo "ERROR: HaRP agent is unresponsive, killing it so the container gets restarted."
+                    kill -TERM "$AGENT_PID" 2>/dev/null
+                    sleep 5
+                    kill -9 "$AGENT_PID" 2>/dev/null
+                    exit 1
+                fi
+            fi
+        done
+    ) &
+    WATCHDOG_PID=$!
+fi
+
+# A trapped signal (e.g. the HUP reload above) interrupts `wait -n` with status > 128,
+# so keep waiting until one of the supervised processes is actually gone.
+dead=""
+while [ -z "$dead" ]; do
+    wait -n
+    rc=$?
+    for entry in "haproxy:$HAPROXY_PID" "agent:$AGENT_PID" "frps:$FRPS_PID" ${FRPC_PID:+"frpc:$FRPC_PID"} ${WATCHDOG_PID:+"watchdog:$WATCHDOG_PID"}; do
+        kill -0 "${entry#*:}" 2>/dev/null || { dead="${entry%%:*}"; break; }
+    done
+done
+echo "ERROR: HaRP process '${dead}' exited unexpectedly (status ${rc}), stopping the container."
+[ -n "${WATCHDOG_PID:-}" ] && kill "$WATCHDOG_PID" 2>/dev/null
+kill -TERM "$HAPROXY_PID" "$AGENT_PID" "$FRPS_PID" ${FRPC_PID:+"$FRPC_PID"} 2>/dev/null
+wait
+exit 1


### PR DESCRIPTION
Fixes #110: the outages are not HAProxy refusing to reconnect, they happen because the whole Python agent (SPOA auth, the control API and the `frps` Login hook share one event loop) stops responding under load, the SPOP check tolerates only about 6 seconds of that before all `/exapps` routing goes down, and nothing detects or restarts a hung agent.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
