### PR TITLE
fix: idle WebSocket connections are dropped after 30 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ HaRP is configured via several environment variables. Here are the key variables
     - **Description:** Timeout for server-side connections. Also caps how long an established streaming response (for example an SSE stream) may stay idle. **We do not recommend to change this value.**
     - **Default:** `1800s`
   - **`HP_TIMEOUT_TUNNEL`**
-    - **Description:** Inactivity timeout for upgraded connections (WebSockets). A value of `0` is treated as unlimited (mapped to HAProxy's `24d` maximum), at the cost of vanished peers holding connections open for a very long time.
+    - **Description:** Inactivity timeout for upgraded connections (WebSockets). A value of `0` is treated as unlimited (mapped to HAProxy's `24d` maximum), at the cost of vanished peers holding connections open for a very long time. Unlimited applies only while the connection stays open in both directions: half-closed connections are still reaped after 30 seconds.
     - **Default:** the value of `HP_TIMEOUT_SERVER` (`1800s`)
   - **`HP_BLACKLIST_WINDOW`**
     - **Description:** Timeout after which an IP is removed from the blacklist, in seconds.

--- a/README.md
+++ b/README.md
@@ -290,11 +290,14 @@ HaRP is configured via several environment variables. Here are the key variables
     - **Description:** Maximum time allowed for establishing a connection.
     - **Default:** `30s`
   - **`HP_TIMEOUT_CLIENT`**
-    - **Description:** Timeout for client-side connections.
+    - **Description:** Inactivity timeout for the request phase, while HaRP waits for the client to send its request. It does not apply to established streaming responses (SSE), which are governed by `HP_TIMEOUT_SERVER`. **We do not recommend to change this value**, as raising it weakens protection against slow clients.
     - **Default:** `30s`
   - **`HP_TIMEOUT_SERVER`**
-    - **Description:** Timeout for server-side connections. **We do not recommend to change this value.**
+    - **Description:** Timeout for server-side connections. Also caps how long an established streaming response (for example an SSE stream) may stay idle. **We do not recommend to change this value.**
     - **Default:** `1800s`
+  - **`HP_TIMEOUT_TUNNEL`**
+    - **Description:** Inactivity timeout for upgraded connections (WebSockets). A value of `0` is treated as unlimited (mapped to HAProxy's `24d` maximum), at the cost of vanished peers holding connections open for a very long time.
+    - **Default:** the value of `HP_TIMEOUT_SERVER` (`1800s`)
   - **`HP_BLACKLIST_WINDOW`**
     - **Description:** Timeout after which an IP is removed from the blacklist, in seconds.
     - **Default:** `300`

--- a/haproxy.cfg.template
+++ b/haproxy.cfg.template
@@ -11,6 +11,7 @@
 #   HP_TIMEOUT_CONNECT,
 #   HP_TIMEOUT_CLIENT,
 #   HP_TIMEOUT_SERVER,
+#   HP_TIMEOUT_TUNNEL,
 #
 # If /certs/cert.pem is not found, lines containing "_HTTPS_FRONTEND_" are
 # commented out automatically in start.sh.
@@ -28,6 +29,11 @@ defaults
     timeout connect ${HP_TIMEOUT_CONNECT}
     timeout client ${HP_TIMEOUT_CLIENT}
     timeout server ${HP_TIMEOUT_SERVER}
+    # Idle timeout for upgraded connections (WebSockets); without it idle tunnels
+    # fall back to the much shorter client timeout.
+    timeout tunnel ${HP_TIMEOUT_TUNNEL}
+    # Reap half-closed connections instead of holding them for the whole tunnel timeout.
+    timeout client-fin 30s
 
 
 ###############################################################################

--- a/start.sh
+++ b/start.sh
@@ -47,7 +47,7 @@ HP_WATCHDOG_FAILS=${HP_WATCHDOG_FAILS:-12}
 # mapped to HAProxy's 24d maximum.
 # Exported explicitly: unlike the Dockerfile ENV timeouts it must reach envsubst below.
 HP_TIMEOUT_TUNNEL="${HP_TIMEOUT_TUNNEL:-${HP_TIMEOUT_SERVER:-1800s}}"
-if [[ "$HP_TIMEOUT_TUNNEL" =~ ^0(ms|s|m|h|d)?$ ]]; then
+if [[ "$HP_TIMEOUT_TUNNEL" =~ ^0(us|ms|s|m|h|d)?$ ]]; then
     HP_TIMEOUT_TUNNEL="24d"
 fi
 export HP_TIMEOUT_TUNNEL

--- a/start.sh
+++ b/start.sh
@@ -41,6 +41,17 @@ HP_WATCHDOG_FAILS=${HP_WATCHDOG_FAILS:-12}
 [ "$HP_WATCHDOG_INTERVAL" -ge 1 ] 2>/dev/null || { echo "WARNING: invalid HP_WATCHDOG_INTERVAL '${HP_WATCHDOG_INTERVAL}', using 10."; HP_WATCHDOG_INTERVAL=10; }
 [ "$HP_WATCHDOG_FAILS" -ge 1 ] 2>/dev/null || { echo "WARNING: invalid HP_WATCHDOG_FAILS '${HP_WATCHDOG_FAILS}', using 12."; HP_WATCHDOG_FAILS=12; }
 
+# WebSocket/tunnel idle timeout: defaults to HP_TIMEOUT_SERVER so raising the server
+# timeout covers tunnels as well. "0" means unlimited; HAProxy itself has no infinite
+# value for "timeout tunnel" (a literal 0 falls back to the client timeout), so it is
+# mapped to HAProxy's 24d maximum.
+# Exported explicitly: unlike the Dockerfile ENV timeouts it must reach envsubst below.
+HP_TIMEOUT_TUNNEL="${HP_TIMEOUT_TUNNEL:-${HP_TIMEOUT_SERVER:-1800s}}"
+if [[ "$HP_TIMEOUT_TUNNEL" =~ ^0(ms|s|m|h|d)?$ ]]; then
+    HP_TIMEOUT_TUNNEL="24d"
+fi
+export HP_TIMEOUT_TUNNEL
+
 HP_VERBOSE_START=${HP_VERBOSE_START:-1}
 log() {
     if [ "$HP_VERBOSE_START" -eq 1 ]; then


### PR DESCRIPTION
While investigating #114 I found that idle WebSocket connections through HaRP are closed after exactly 30 seconds: the config defines no `timeout tunnel`, so after the 101 upgrade HAProxy falls back to `timeout client` for the tunnel, and any ExApp WebSocket that does not ping more often than that gets cut (termination flags `cD--` in the access log).

This adds `timeout tunnel`, configurable through a new `HP_TIMEOUT_TUNNEL` variable that defaults to the value of `HP_TIMEOUT_SERVER` (1800s), so raising the server timeout keeps tunnels covered too. Setting it to `0` means unlimited: HAProxy has no infinite value for this timeout (a literal `timeout tunnel 0` silently falls back to the client timeout again, verified live), so start.sh maps `0` to HAProxy's `24d` maximum. Also adds `timeout client-fin 30s` so half-closed tunnels are reaped quickly instead of lingering for the whole tunnel timeout.

Tested live against a probe ExApp connected through a real FRP tunnel: on the current release an idle WebSocket dies at 30.0s; with this change it survives 120s of idle with the default, an explicit `HP_TIMEOUT_TUNNEL=15s` cuts it at 15s, and `0` keeps it alive. SSE streams (idle, headers-only, with pings), slow responses and the 30s request-phase client timeout all behave exactly as before.
