### PR TITLE
chore: update base image to HAProxy 3.2 LTS on Alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #  - HP_SHARED_KEY or HP_SHARED_KEY_FILE must be provided at runtime.
 # -------------------------------------------------------------------------
 
-FROM docker.io/library/haproxy:3.1.2-alpine3.21
+FROM docker.io/library/haproxy:3.2.22-alpine3.24
 
 USER root
 
@@ -67,7 +67,7 @@ RUN set -ex; \
 
 # Install the Python SPOA library
 RUN pip install --break-system-packages \
-        pydantic==2.10.6 \
+        pydantic==2.13.4 \
         git+https://github.com/cloud-py-api/haproxy-python-spoa.git
 
 # Copy our scripts and templates

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,13 @@ RUN set -ex; \
         netcat-openbsd; \
     chmod -R 777 /tmp;
 
-# Install the Python SPOA library
+# Install the Python SPOA library.
+# Pinned to a commit: the single-write frame emission it contains is required for
+# HAProxy 3.2+, whose SPOP mux resets connections when a frame arrives split
+# across TCP segments. Bump this deliberately together with the library.
 RUN pip install --break-system-packages \
         pydantic==2.13.4 \
-        git+https://github.com/cloud-py-api/haproxy-python-spoa.git
+        git+https://github.com/cloud-py-api/haproxy-python-spoa.git@f00f3f7b1b0f56e10052af6c0d07e81c5195d84d
 
 # Copy our scripts and templates
 COPY --chmod=755 healthcheck.sh /healthcheck.sh

--- a/development/debugging/Dockerfile
+++ b/development/debugging/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM haproxy:3.1.2-alpine3.21
+FROM haproxy:3.2.22-alpine3.24
 
 USER root
 


### PR DESCRIPTION
HAProxy 3.1 is unmaintained since Q1 2026 and Docker Hub no longer rebuilds 3.1 images, so this moves the base image to the current LTS branch (3.2.22, supported until Q2 2030) on Alpine 3.24.

Alpine 3.24 ships Python 3.14, and the pinned pydantic 2.10.6 has no wheels for it, so pydantic moves to 2.13.4 (cp314 musl wheels for both amd64 and arm64). No code or config changes needed: haproxy -c is clean on 3.2.

Verified live besides CI: SPOA auth and routing, FRP tunnels, timeout semantics (client, server, tunnel including the 0 to 24d unlimited mapping), idle WebSocket survival, and a full app-skeleton-python deploy lifecycle through the new image.