### PR TITLE
chore: update base image to HAProxy 3.4 LTS and track LTS in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,32 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":disableDependencyDashboard"
   ],
   "ignorePaths": [
     "**/tests/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Track only HAProxy LTS branches. Upstream ships LTS on even minors (3.0, 3.2, 3.4, ...) with ~5 years of support; odd minors (3.1, 3.3, ...) are non-LTS and go EOL about a year after release. See https://www.haproxy.org/ for branch status.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["docker.io/library/haproxy", "haproxy"],
+      "allowedVersions": "/^\\d+\\.\\d*[02468](\\.\\d+)?(-alpine.*)?$/",
+      "groupName": "haproxy base image"
+    },
+    {
+      "description": "A HAProxy minor bump can change SPOP mux behaviour, which the pinned haproxy-python-spoa commit compensates for. Keep those PRs separate from routine patch bumps so the SPOE agent gets tested against the new branch.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["docker.io/library/haproxy", "haproxy"],
+      "matchUpdateTypes": ["major", "minor"],
+      "groupName": "haproxy LTS branch upgrade",
+      "addLabels": ["needs-spoe-testing"]
+    },
+    {
+      "description": "Group GitHub Actions bumps into a single PR.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #  - HP_SHARED_KEY or HP_SHARED_KEY_FILE must be provided at runtime.
 # -------------------------------------------------------------------------
 
-FROM docker.io/library/haproxy:3.2.22-alpine3.24
+FROM docker.io/library/haproxy:3.4.4-alpine3.24
 
 USER root
 
@@ -67,8 +67,8 @@ RUN set -ex; \
 
 # Install the Python SPOA library.
 # Pinned to a commit: the single-write frame emission it contains is required for
-# HAProxy 3.2+, whose SPOP mux resets connections when a frame arrives split
-# across TCP segments. Bump this deliberately together with the library.
+# HAProxy 3.2+ (we run 3.4 LTS), whose SPOP mux resets connections when a frame
+# arrives split across TCP segments. Bump this deliberately together with the library.
 RUN pip install --break-system-packages \
         pydantic==2.13.4 \
         git+https://github.com/cloud-py-api/haproxy-python-spoa.git@f00f3f7b1b0f56e10052af6c0d07e81c5195d84d

--- a/development/debugging/Dockerfile
+++ b/development/debugging/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM haproxy:3.2.22-alpine3.24
+FROM haproxy:3.4.4-alpine3.24
 
 USER root
 


### PR DESCRIPTION
## Summary

Moves the production and debugging images from HAProxy **3.2.22 → 3.4.4** on Alpine 3.24, and configures Renovate to keep the base image on LTS branches going forward.

3.4 is the current LTS branch, supported until **2031-Q2**; 3.2 reaches EOL in 2030-Q2.

### Why not 3.3

3.3.14 is published and newer than our previous pin, but 3.3 is a **non-LTS** branch that stops receiving fixes around **2027-Q1**. Moving to it would have shortened our support horizon rather than extending it.

| Branch | Status | Supported until |
|---|---|---|
| **3.4** | **LTS** | **2031-Q2** |
| 3.3 | stable (non-LTS) | 2027-Q1 |
| 3.2 (previous) | LTS | 2030-Q2 |
| 3.1 | unmaintained | — |

## SPOE verification

The pinned `haproxy-python-spoa` commit (`f00f3f7`) is **unchanged** — it is still upstream HEAD, so there was nothing to co-bump. That pin exists because HAProxy 3.2+ resets SPOP connections when a frame arrives split across TCP segments, so a two-minor jump is exactly the change that could break it.

Verified locally against 3.4.4:

- Both images build clean; HAProxy self-reports `long-term supported branch - will stop receiving fixes around Q2 2031`.
- Container starts and reports **healthy**; SPOA, FRP, and HAProxy all come up.
- Traffic driven through the exapps frontend returns SPOE verdicts for request paths up to **6 KB** and headers up to **7 KB** — multi-segment frames, the case the single-write pin addresses.
- **No** SPOP frame, mux, or reset errors in the logs. Agent process alive and healthcheck passing afterward.

Runtime deps resolve as expected: `haproxyspoa`, pydantic 2.13.4, aiohttp 3.13.5, and FRP 0.65.0 from Alpine.

## Renovate

- `config:base` → `config:recommended` (the old preset is deprecated).
- Base image constrained to **LTS branches only**. HAProxy ships LTS on even minors, so the rule matches that shape rather than a fixed version ceiling — a `<3.5` cap would have let a future non-LTS branch through on the next cycle. Regex tested against real published tags: allows 3.4/3.2/3.0/2.8 and `3.10.x`, rejects 3.3/3.1.
- Minor/major bumps are split into their own PR labelled `needs-spoe-testing`, since those are the ones that can change SPOP mux behaviour. Patch bumps stay routine.
- GitHub Actions bumps grouped into a single PR.

## Notes for review

- `renovate-config-validator` was **not** run — it needs Node 18+ and the local environment has v16. The JSON parses and the fields match the documented schema, but CI or a reviewer with a newer Node should confirm.
- Unrelated and left for a follow-up: `ARG FRP_VERSION=0.61.1` in `README.md` is stale, since the image now ships FRP 0.65.0.
