### PR TITLE
fix(k8s): fail fast in /info when the API server does not answer

### DIFF
--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -58,6 +58,9 @@ if not K8S_API_SERVER and os.environ.get("KUBERNETES_SERVICE_HOST"):
     K8S_API_SERVER = f"https://{host}:{port}"
 
 K8S_HTTP_TIMEOUT = aiohttp.ClientTimeout(total=60.0)
+# `/info` probes the API server with its own short timeout: AppAPI waits 5 s for `/info` in its daemon checks, so a
+# probe that inherits K8S_HTTP_TIMEOUT makes an unreachable API server look like an unreachable HaRP.
+K8S_PROBE_TIMEOUT = aiohttp.ClientTimeout(total=3.0)
 _k8s_session: aiohttp.ClientSession | None = None
 K8S_NAME_MAX_LENGTH = 63
 # Set up the logging configuration
@@ -832,12 +835,10 @@ async def get_info(request: web.Request):
     k8s_status: dict[str, Any] = {"enabled": K8S_ENABLED}
     if K8S_ENABLED:
         k8s_status["api_server"] = K8S_API_SERVER or ""
-        try:
-            _ensure_k8s_configured()
-            status, _, _ = await _k8s_request("GET", "/api")
-            k8s_status["reachable"] = status == 200
-        except Exception:
-            k8s_status["reachable"] = False
+        reachable, error = await _k8s_probe()
+        k8s_status["reachable"] = reachable
+        if error:
+            k8s_status["error"] = error
 
     return web.json_response({
         "version": HARP_VERSION,
@@ -2270,6 +2271,42 @@ async def _k8s_request(
     except aiohttp.ClientError as e:
         LOGGER.error("Error communicating with Kubernetes API (%s %s): %s", method, url, e)
         raise web.HTTPServiceUnavailable(text="Error communicating with Kubernetes API") from e
+
+
+async def _k8s_probe() -> tuple[bool, str]:
+    """Check whether the Kubernetes API server answers; returns ``(reachable, error)``.
+
+    Used by ``/info`` only. Unlike ``_k8s_request`` it fails fast (K8S_PROBE_TIMEOUT) and keeps the reason, so the
+    AppAPI daemon check can tell a broken cluster connection from a broken HaRP one.
+    """
+    try:
+        _ensure_k8s_configured()
+    except web.HTTPServiceUnavailable as e:
+        return False, e.text or "Kubernetes backend is not configured."
+    url = f"{K8S_API_SERVER}/api"
+    headers = {"Authorization": f"Bearer {_get_k8s_token()}", "Accept": "application/json"}
+    try:
+        session = _get_k8s_session()  # may raise on a broken HP_K8S_CA_FILE
+        async with session.get(url, headers=headers, timeout=K8S_PROBE_TIMEOUT) as resp:
+            if resp.status == 200:
+                return True, ""
+            if resp.status in (401, 403):
+                error = (
+                    f"Kubernetes API server answered HTTP {resp.status}; check the bearer token "
+                    "(HP_K8S_BEARER_TOKEN or HP_K8S_BEARER_TOKEN_FILE)."
+                )
+            else:
+                error = f"Kubernetes API server answered HTTP {resp.status}."
+    except TimeoutError:
+        error = f"Kubernetes API server did not answer within {K8S_PROBE_TIMEOUT.total:g}s (DNS, connect or request)."
+    except aiohttp.ClientSSLError as e:
+        error = f"TLS error connecting to the Kubernetes API server: {e}"
+    except aiohttp.ClientError as e:
+        error = f"Cannot connect to the Kubernetes API server: {e}"
+    except Exception as e:  # `/info` must always answer
+        error = f"Kubernetes API probe failed: {e}"
+    LOGGER.warning("Kubernetes API probe (%s) failed: %s", url, error)
+    return False, error
 
 
 def _k8s_parse_env(env_list: list[str]) -> list[dict[str, str]]:

--- a/haproxy_agent.py
+++ b/haproxy_agent.py
@@ -832,6 +832,7 @@ async def get_heartbeat(request: web.Request):
 
 
 async def get_info(request: web.Request):
+    """Report HaRP's version and backend status; used by the AppAPI daemon check."""
     k8s_status: dict[str, Any] = {"enabled": K8S_ENABLED}
     if K8S_ENABLED:
         k8s_status["api_server"] = K8S_API_SERVER or ""
@@ -2288,15 +2289,24 @@ async def _k8s_probe() -> tuple[bool, str]:
     try:
         session = _get_k8s_session()  # may raise on a broken HP_K8S_CA_FILE
         async with session.get(url, headers=headers, timeout=K8S_PROBE_TIMEOUT) as resp:
+            # Read the body inside the context, like `_k8s_request` does: it carries the Kubernetes `Status.message`
+            # that says what actually went wrong, and leaving it unread makes aiohttp drop the pooled connection
+            # whenever the body does not arrive with the headers.
+            body = (await resp.text())[:200].strip()
             if resp.status == 200:
                 return True, ""
-            if resp.status in (401, 403):
+            if resp.status == 401:
                 error = (
-                    f"Kubernetes API server answered HTTP {resp.status}; check the bearer token "
+                    "Kubernetes API server answered HTTP 401; check the bearer token "
                     "(HP_K8S_BEARER_TOKEN or HP_K8S_BEARER_TOKEN_FILE)."
                 )
+            elif resp.status == 403:
+                # 401 is authentication, 403 is authorization: a valid token can still be denied by RBAC.
+                error = "Kubernetes API server answered HTTP 403; check the bearer token's RBAC permissions."
             else:
                 error = f"Kubernetes API server answered HTTP {resp.status}."
+            if body:
+                error = f"{error} Response: {body}"
     except TimeoutError:
         error = f"Kubernetes API server did not answer within {K8S_PROBE_TIMEOUT.total:g}s (DNS, connect or request)."
     except aiohttp.ClientSSLError as e:


### PR DESCRIPTION
The `/info` probe of the Kubernetes API server inherited `K8S_HTTP_TIMEOUT` (60 s). AppAPI waits 5 s for `/info` in its daemon checks, so an unreachable API server surfaced as "Cannot reach HaRP: cURL error 28" after a 5 s hang on every admin page load and Check connection.

The probe now has its own 3 s timeout (has to stay below AppAPI's 5 s) and `/info` reports why the cluster is unreachable in a new `error` field, e.g. `HTTP 401` with a token hint, TLS error, connection refused, or timeout. `reachable` keeps its meaning, so current AppAPI releases are unaffected.

Tested against a kind cluster with the API server paused: `/info` 60 s -> 3 s, AppAPI daemon check 5.3 s with the wrong message -> 3.3 s with the right one; ExApp deploy/disable/enable/unregister through the patched HaRP unchanged.
